### PR TITLE
Fix chart requires kubeVersion: >=1.19.0 which is incompatible with Kubernetes v1.31.1-eks-ce1d5eb

### DIFF
--- a/loki/extension.yaml
+++ b/loki/extension.yaml
@@ -26,7 +26,7 @@ provider:
     url: https://kubesphere.co/
 staticFileDirectory: static
 sources: []
-kubeVersion: '>=1.19.0'
+kubeVersion: '>=1.19.0-0'
 ksVersion: '>=4.0.0-0'
 icon: ./static/loki.png
 dependencies:

--- a/network/extension.yaml
+++ b/network/extension.yaml
@@ -16,7 +16,7 @@ keywords:
   - networkpolicy
 home: https://kubesphere.com.cn/
 sources: []
-kubeVersion: '>=1.19.0'
+kubeVersion: '>=1.19.0-0'
 ksVersion: '>=4.1.1-0'
 maintainers:
   - name: KubeSphere


### PR DESCRIPTION
```release-note
Fix extension kubeVersion for Loki and Network to be compatible with K8s 1.31.1 
```
<img width="882" alt="image" src="https://github.com/user-attachments/assets/9168418e-0520-4575-82b0-e35ab2f61377">
