### PR TITLE
Update incorrect images for extensions

### DIFF
--- a/gatekeeper/values.yaml
+++ b/gatekeeper/values.yaml
@@ -270,7 +270,7 @@ agent:
   apiserver:
     image:
       repository: kubesphere/gatekeeper-extension-apiserver
-      tag: "v1.0.0"
+      tag: "v1.0.1"
       pullPolicy: IfNotPresent
   kubectl:
     image:

--- a/loki/extension.yaml
+++ b/loki/extension.yaml
@@ -43,6 +43,8 @@ images:
   - docker.io/library/memcached:1.6.23-alpine
   - docker.io/prom/memcached-exporter:v0.14.2
   - docker.io/kiwigrid/k8s-sidecar:1.24.3
+  - docker.io/minio/minio:RELEASE.2022-09-17T00-09-45Z
+  - docker.io/minio/mc:RELEASE.2022-09-16T09-16-47Z
 maintainers:
   - name: KubeSphere
     email: kubesphere@yunify.com

--- a/opensearch/extension.yaml
+++ b/opensearch/extension.yaml
@@ -46,10 +46,10 @@ dependencies:
       - agent
 installationMode: Multicluster
 images:
-  - docker.io/opensearchproject/opensearch:2.11.1
+  - docker.io/opensearchproject/opensearch:2.8.0
   - docker.io/library/busybox:1.35.0
   - docker.io/kubesphere/opensearch-curator:v0.0.5
-  - docker.io/opensearchproject/opensearch-dashboards:2.11.1
+  - docker.io/opensearchproject/opensearch-dashboards:2.8.0
 maintainers:
   - name: KubeSphere
     email: kubesphere@yunify.com

--- a/opensearch/values.yaml
+++ b/opensearch/values.yaml
@@ -34,6 +34,8 @@ opensearch-data:
 
 opensearch-dashboards:
   enabled: false
+  image:
+    tag: "2.8.0"
 opensearch-curator:
   enabled: true
 #  configMaps:


### PR DESCRIPTION
```release-note
None
```

gatekeeper:
`docker.io/kubesphere/gatekeeper-extension-apiserver:v1.0.1` does not match the config in values.yaml
opensearch:
`docker.io/opensearchproject/opensearch:2.11.1` does not match the config in values.yaml
loki:
missing `docker.io/minio/minio:RELEASE.2022-09-17T00-09-45Z` 
missing `docker.io/minio/mc:RELEASE.2022-09-16T09-16-47Z` 