### PR TITLE
[metrics-server] update extension

### DIFF
--- a/metrics-server/CHANGELOG.md
+++ b/metrics-server/CHANGELOG.md
@@ -3,6 +3,12 @@ Please do not delete this line of version tag
 RELEASE_MARK v4.1.0 RELEASE_MARK
 Please do not delete this line of version tag
 -->
+## v0.7.1
+
+### Enhancements
+
+- Supports not enabling the deployment of the built-in metrics-server Helm charts during the installation of extension.
+
 ## v0.7.0
 
 This is the first official version of metrics-server adapted for KubeSphere v4 LuBan pluggable architecture. It only customizes [metrics-server](https://github.com/kubernetes-sigs/metrics-server) to comply with KubeSphere v4 Luban extensions without modifying its code, images, etc.

--- a/metrics-server/CHANGELOG_zh.md
+++ b/metrics-server/CHANGELOG_zh.md
@@ -3,6 +3,12 @@ Please do not delete this line of version tag
 RELEASE_MARK v4.1.0 RELEASE_MARK
 Please do not delete this line of version tag
 -->
+## v0.7.1
+
+### 优化
+
+- 支持不启用部署内置的 metrics-server Helm charts 在扩展组件安装时
+
 ## v0.7.0
 
 这是 metrics-server 适配 KubeSphere v4 LuBan 可插拔架构的第一个正式版本，仅将 [metrics-server](https://github.com/kubernetes-sigs/metrics-server) 定制为符合 KubeSphere  v4 LuBan 可插拔架构的扩展插件，未对其代码、镜像等进行任何修改。

--- a/metrics-server/CHANGELOG_zh.md
+++ b/metrics-server/CHANGELOG_zh.md
@@ -7,7 +7,7 @@ Please do not delete this line of version tag
 
 ### 优化
 
-- 支持不启用部署内置的 metrics-server Helm charts 在扩展组件安装时
+- 支持在扩展组件安装时不启用部署内置的 metrics-server Helm charts 
 
 ## v0.7.0
 

--- a/metrics-server/extension.yaml
+++ b/metrics-server/extension.yaml
@@ -1,6 +1,6 @@
 apiVersion: kubesphere.io/v1alpha1
 name: metrics-server
-version: 0.7.0
+version: 0.7.1
 displayName:
   zh: Metrics Server
   en: Metrics Server
@@ -35,6 +35,7 @@ dependencies:
   - name: metrics-server
     tags:
       - agent
+    condition: metricsServer.enabled
 # installationMode describes how to install subcharts, it can be HostOnly or Multicluster.
 # In Multicluster mode, the subchart with tag `extension` will only be deployed to the host cluster,
 # and the subchart with tag `agent` will be deployed to all selected clusters.

--- a/metrics-server/values.yaml
+++ b/metrics-server/values.yaml
@@ -2,6 +2,9 @@ global:
   imageRegistry: ""
   imagePullSecrets: []
 
+metricsServer:
+  enabled: true
+
 metrics-server:
   fullnameOverride: "metrics-server"
 


### PR DESCRIPTION
```release-note
[metrics-server] Supports not enabling the deployment of the built-in metrics-server Helm charts during the installation of extension.
```